### PR TITLE
Update USPS tracking email to auto-reply@tracking.usps.com

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -283,20 +283,20 @@ AMAZON_DELIEVERED_BY_OTHERS_SEARCH_TEXT = ["AMAZON"]
 SENSOR_DATA = {
     # USPS
     "usps_delivered": {
-        "email": ["auto-reply@usps.com"],
+        "email": ["auto-reply@usps.com", "auto-reply@tracking.usps.com"],
         "subject": ["Item Delivered"],
     },
     "usps_delivering": {
-        "email": ["auto-reply@usps.com"],
+        "email": ["auto-reply@usps.com", "auto-reply@tracking.usps.com"],
         "subject": ["Expected Delivery on", "Out for Delivery"],
         "body": ["Your item is out for delivery"],
     },
     "usps_exception": {
-        "email": ["auto-reply@usps.com"],
+        "email": ["auto-reply@usps.com", "auto-reply@tracking.usps.com"],
         "subject": ["Delivery Exception"],
     },
     "usps_packages": {
-        "email": ["auto-reply@usps.com"],
+        "email": ["auto-reply@usps.com", "auto-reply@tracking.usps.com"],
         "subject": ["Expected Delivery by"],
     },
     "usps_tracking": {"pattern": ["9[2345]\\d{15,26}"]},

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -41,6 +41,7 @@ def test_generate_service_email_domains():
     assert "amazon.co.uk" in domains
     # USPS is in SENSOR_DATA default emails
     assert "usps.com" in domains
+    assert "tracking.usps.com" in domains
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
USPS has updated their package tracking email to auto-reply@tracking.usps.com. This PR adds auto-reply@tracking.usps.com to all four USPS package tracking email address lists while keeping auto-reply@usps.com for backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USPS package tracking detection to recognize notifications from additional email sources, reducing the chance of missing delivery updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/Home-Assistant-Mail-And-Packages/pull/1?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->