### PR TITLE
feat: Multi-folder IMAP search with ESEARCH/MULTISEARCH support

### DIFF
--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -296,6 +296,15 @@ async def _validate_user_input(user_input: dict) -> tuple:
     # Validate file paths
     _validate_path_input(user_input, errors)
 
+    # Normalize CONF_FOLDER: if it has exactly 1 folder, store as string
+    if CONF_FOLDER in user_input:
+        folder_val = user_input[CONF_FOLDER]
+        if isinstance(folder_val, (list, set, tuple)):
+            if len(folder_val) == 1:
+                user_input[CONF_FOLDER] = list(folder_val)[0]
+            else:
+                user_input[CONF_FOLDER] = list(folder_val)
+
     return errors, user_input
 
 
@@ -449,20 +458,29 @@ async def _get_schema_step_2(
         """Get default value for key."""
         return user_input.get(key, default_dict.get(key, fallback_default))
 
+    default_folder = _get_default(CONF_FOLDER)
+    if isinstance(default_folder, str):
+        default_folder = [default_folder]
+
+    mailboxes = await _get_mailboxes(
+        hass,
+        data[CONF_HOST],
+        data[CONF_PORT],
+        data[CONF_USERNAME],
+        data.get(CONF_PASSWORD, ""),
+        data[CONF_IMAP_SECURITY],
+        data[CONF_VERIFY_SSL],
+        data.get("token", {}).get("access_token"),
+    )
+
+    def multi_folder_select(value):
+        if isinstance(value, str):
+            value = [value]
+        return cv.multi_select(mailboxes)(value)
+
     return vol.Schema(
         {
-            vol.Required(CONF_FOLDER, default=_get_default(CONF_FOLDER)): vol.In(
-                await _get_mailboxes(
-                    hass,
-                    data[CONF_HOST],
-                    data[CONF_PORT],
-                    data[CONF_USERNAME],
-                    data.get(CONF_PASSWORD, ""),
-                    data[CONF_IMAP_SECURITY],
-                    data[CONF_VERIFY_SSL],
-                    data.get("token", {}).get("access_token"),
-                ),
-            ),
+            vol.Required(CONF_FOLDER, default=default_folder): multi_folder_select,
             vol.Required(
                 CONF_RESOURCES,
                 default=_get_default(CONF_RESOURCES),

--- a/custom_components/mail_and_packages/config_flow.py
+++ b/custom_components/mail_and_packages/config_flow.py
@@ -300,10 +300,15 @@ async def _validate_user_input(user_input: dict) -> tuple:
     if CONF_FOLDER in user_input:
         folder_val = user_input[CONF_FOLDER]
         if isinstance(folder_val, (list, set, tuple)):
-            if len(folder_val) == 1:
-                user_input[CONF_FOLDER] = list(folder_val)[0]
+            folder_list = [f for f in folder_val if isinstance(f, str) and f]
+            if not folder_list:
+                user_input[CONF_FOLDER] = "INBOX"
+            elif len(folder_list) == 1:
+                user_input[CONF_FOLDER] = folder_list[0]
             else:
-                user_input[CONF_FOLDER] = list(folder_val)
+                user_input[CONF_FOLDER] = folder_list
+        elif not isinstance(folder_val, str) or not folder_val:
+            user_input[CONF_FOLDER] = "INBOX"
 
     return errors, user_input
 
@@ -459,8 +464,16 @@ async def _get_schema_step_2(
         return user_input.get(key, default_dict.get(key, fallback_default))
 
     default_folder = _get_default(CONF_FOLDER)
-    if isinstance(default_folder, str):
+    if not default_folder:
+        default_folder = ["INBOX"]
+    elif isinstance(default_folder, str):
         default_folder = [default_folder]
+    elif isinstance(default_folder, (list, tuple, set)):
+        default_folder = [f for f in default_folder if isinstance(f, str) and f]
+        if not default_folder:
+            default_folder = ["INBOX"]
+    else:
+        default_folder = ["INBOX"]
 
     mailboxes = await _get_mailboxes(
         hass,

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -236,16 +236,23 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.error("Error logging into IMAP: %s", err)
             raise UpdateFailed(f"Login failed: {err}") from err
 
-        try:
-            folder_ok = await selectfolder(account, config.get(CONF_FOLDER))
-        except Exception as err:
-            await logout(account)
-            raise UpdateFailed(f"Folder selection failed: {err}") from err
+        folders = config.get(CONF_FOLDER)
+        if isinstance(folders, str):
+            folders = [folders]
+        account._folders = folders  # noqa: SLF001
+        account._current_folder = None  # noqa: SLF001
 
-        if not folder_ok:
-            _LOGGER.error("Error selecting folder: %s", config.get(CONF_FOLDER))
-            await logout(account)
-            raise UpdateFailed(f"Folder selection failed: {config.get(CONF_FOLDER)}")
+        if folders:
+            try:
+                folder_ok = await selectfolder(account, folders[0])
+            except Exception as err:
+                await logout(account)
+                raise UpdateFailed(f"Folder selection failed: {err}") from err
+
+            if not folder_ok:
+                _LOGGER.error("Error selecting folder: %s", folders[0])
+                await logout(account)
+                raise UpdateFailed(f"Folder selection failed: {folders[0]}")
 
         return account
 

--- a/custom_components/mail_and_packages/coordinator.py
+++ b/custom_components/mail_and_packages/coordinator.py
@@ -237,8 +237,16 @@ class MailDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"Login failed: {err}") from err
 
         folders = config.get(CONF_FOLDER)
-        if isinstance(folders, str):
+        if not folders:
+            folders = ["INBOX"]
+        elif isinstance(folders, str):
             folders = [folders]
+        elif isinstance(folders, (list, tuple, set)):
+            folders = [f for f in folders if isinstance(f, str) and f]
+            if not folders:
+                folders = ["INBOX"]
+        else:
+            folders = ["INBOX"]
         account._folders = folders  # noqa: SLF001
         account._current_folder = None  # noqa: SLF001
 

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -2,13 +2,29 @@
 
 import asyncio
 import logging
+import re
 
-from aioimaplib import AUTH, IMAP4, IMAP4_SSL, NONAUTH, SELECTED, AioImapException
+import aioimaplib
+from aioimaplib import (
+    AUTH,
+    IMAP4,
+    IMAP4_SSL,
+    NONAUTH,
+    SELECTED,
+    AioImapException,
+    Cmd,
+    Command,
+    Exec,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import ssl
 
 _LOGGER = logging.getLogger(__name__)
+
+# Register ESEARCH command if not already present in aioimaplib
+if "ESEARCH" not in aioimaplib.Commands:
+    aioimaplib.Commands["ESEARCH"] = Cmd("ESEARCH", (AUTH, SELECTED), Exec.is_async)
 
 
 class InvalidAuth(HomeAssistantError):
@@ -61,6 +77,9 @@ async def login(
 
 async def selectfolder(account: IMAP4_SSL, folder: str) -> bool:
     """Select folder inside the mailbox asynchronously."""
+    if getattr(account, "_current_folder", None) == folder:
+        return True
+
     try:
         await account.list(folder, "*")
     except (AioImapException, OSError) as err:
@@ -73,6 +92,7 @@ async def selectfolder(account: IMAP4_SSL, folder: str) -> bool:
         _LOGGER.error("Error selecting folder %s: %s", folder, err)
         return False
     else:
+        account._current_folder = folder  # noqa: SLF001
         return True
 
 
@@ -145,7 +165,103 @@ def build_search(
     return (False, imap_search)
 
 
-async def email_search(
+_ESEARCH_RE = re.compile(
+    r'\(TAG\s+"[^"]+"\s+MAILBOX\s+"([^"]+)"\s+UIDVALIDITY\s+\d+\)\s+UID\s+ALL\s+(.+)'
+)
+
+
+def _parse_esearch_line(line_bytes: bytes) -> list[bytes]:
+    """Parse a single ESEARCH line and return list of formatted UID bytes: b'folder/uid'."""
+    line_str = line_bytes.decode("utf-8", "ignore")
+    match = _ESEARCH_RE.search(line_str)
+    if not match:
+        return []
+    mailbox = match.group(1)
+    seq_set = match.group(2)
+    uids = []
+    for part in seq_set.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if ":" in part:
+            try:
+                start_str, end_str = part.split(":", 1)
+                start, end = int(start_str), int(end_str)
+                if start <= end:
+                    uids.extend(str(x) for x in range(start, end + 1))
+                else:
+                    uids.extend(str(x) for x in range(end, start + 1))
+            except ValueError:
+                pass
+        else:
+            uids.append(part)
+    return [f"{mailbox}/{uid}".encode() for uid in uids]
+
+
+async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[bytes]:  # noqa: C901
+    """Execute search query. If single folder, use standard search. If multiple, use hybrid ESEARCH/fallback."""
+    folders = getattr(account, "_folders", ["INBOX"])
+
+    if len(folders) <= 1:
+        res = await account.search(search_query, charset=None)
+        if res.result == "OK" and res.lines[0]:
+            return res.lines[0].split()
+        return []
+
+    all_uids = []
+
+    # Check for MULTISEARCH capability safely (handling mock/AsyncMock in tests)
+    is_multisearch = False
+    if hasattr(account, "has_capability"):
+        try:
+            res = account.has_capability("MULTISEARCH")
+            if asyncio.iscoroutine(res):
+                res.close()
+                is_multisearch = False
+            else:
+                is_multisearch = bool(res)
+        except Exception:  # noqa: BLE001
+            pass
+
+    if is_multisearch:
+        # ESEARCH IN ("folder1" "folder2") query
+        folder_list = " ".join([f'"{f}"' for f in folders])
+        args = ("IN", f"({folder_list})", search_query)
+        try:
+            res = await account.protocol.execute(
+                Command(
+                    "ESEARCH",
+                    account.protocol.new_tag(),
+                    *args,
+                    loop=account.protocol.loop,
+                )
+            )
+            if res.result == "OK":
+                for line in res.lines:
+                    if line:
+                        all_uids.extend(_parse_esearch_line(line))
+        except (AioImapException, OSError) as err:
+            _LOGGER.error("Error executing ESEARCH: %s", err)
+    else:
+        # Sequential select and search fallback
+        for folder in folders:
+            select_ok = await selectfolder(account, folder)
+            if not select_ok:
+                continue
+            try:
+                res = await account.uid_search(search_query, charset=None)
+                if res.result == "OK" and res.lines[0]:
+                    all_uids.extend(
+                        f"{folder}/{uid.decode()}".encode()
+                        for uid in res.lines[0].split()
+                    )
+            except (AioImapException, OSError) as err:
+                _LOGGER.error("Error searching folder %s: %s", folder, err)
+
+    return all_uids
+
+
+async def email_search(  # noqa: C901
     account: IMAP4_SSL,
     address: list,
     date: str,
@@ -164,15 +280,44 @@ async def email_search(
     If multiple subjects are provided, they are searched in batches of 10
     to keep the search query length safe.
     """
+    folders = getattr(account, "_folders", ["INBOX"])
+
+    if len(folders) <= 1:
+        if not isinstance(subject, list) or len(subject) <= 10:
+            _unused, search = build_search(address, date, subject, header)
+            try:
+                res = await account.search(search, charset=None)
+            except (AioImapException, OSError) as err:
+                _LOGGER.error("Error searching emails: %s", err)
+                return ("BAD", str(err))
+            else:
+                return (res.result, res.lines)
+
+        # Batch subjects in groups of 10
+        all_matched_ids = []
+        for i in range(0, len(subject), 10):
+            batch = subject[i : i + 10]
+            _unused, search = build_search(address, date, batch, header)
+            try:
+                res = await account.search(search, charset=None)
+                if res.result == "OK" and res.lines[0]:
+                    all_matched_ids.extend(res.lines[0].split())
+            except (AioImapException, OSError) as err:
+                _LOGGER.error("Error searching emails batch: %s", err)
+
+        # Deduplicate and return in same format as individual search
+        unique_ids = list(dict.fromkeys(all_matched_ids))
+        return ("OK", [b" ".join(unique_ids)])
+
+    # Multi-folder search logic
     if not isinstance(subject, list) or len(subject) <= 10:
         _unused, search = build_search(address, date, subject, header)
         try:
-            res = await account.search(search, charset=None)
+            uids = await _execute_single_search(account, search)
         except (AioImapException, OSError) as err:
             _LOGGER.error("Error searching emails: %s", err)
             return ("BAD", str(err))
-        else:
-            return (res.result, res.lines)
+        return ("OK", [b" ".join(uids)])
 
     # Batch subjects in groups of 10
     all_matched_ids = []
@@ -180,9 +325,8 @@ async def email_search(
         batch = subject[i : i + 10]
         _unused, search = build_search(address, date, batch, header)
         try:
-            res = await account.search(search, charset=None)
-            if res.result == "OK" and res.lines[0]:
-                all_matched_ids.extend(res.lines[0].split())
+            uids = await _execute_single_search(account, search)
+            all_matched_ids.extend(uids)
         except (AioImapException, OSError) as err:
             _LOGGER.error("Error searching emails batch: %s", err)
 
@@ -197,6 +341,16 @@ async def email_fetch(account: IMAP4_SSL, num, parts: str = "(RFC822)") -> tuple
         parts = "BODY[]"
 
     num_str = num.decode() if isinstance(num, bytes) else str(num)
+    if "/" in num_str:
+        folder, num_str = num_str.rsplit("/", 1)
+        await selectfolder(account, folder)
+        try:
+            res = await account.uid("FETCH", num_str, parts)
+        except (AioImapException, OSError) as err:
+            _LOGGER.error("Error fetching email %s: %s", num_str, err)
+            return ("BAD", str(err))
+        else:
+            return (res.result, res.lines)
 
     try:
         res = await account.fetch(num_str, parts)
@@ -210,6 +364,16 @@ async def email_fetch(account: IMAP4_SSL, num, parts: str = "(RFC822)") -> tuple
 async def email_fetch_headers(account: IMAP4_SSL, num) -> tuple:
     """Download only the subject header of an email asynchronously."""
     num_str = num.decode() if isinstance(num, bytes) else str(num)
+    if "/" in num_str:
+        folder, num_str = num_str.rsplit("/", 1)
+        await selectfolder(account, folder)
+        try:
+            res = await account.uid("FETCH", num_str, "(BODY[HEADER.FIELDS (SUBJECT)])")
+        except (AioImapException, OSError) as err:
+            _LOGGER.error("Error fetching email headers %s: %s", num_str, err)
+            return ("BAD", str(err))
+        else:
+            return (res.result, res.lines)
 
     try:
         res = await account.fetch(num_str, "(BODY[HEADER.FIELDS (SUBJECT)])")
@@ -226,6 +390,16 @@ async def email_fetch_text(account: IMAP4_SSL, num, parts: str = "(BODY[1])") ->
         parts = "BODY[]"
 
     num_str = num.decode() if isinstance(num, bytes) else str(num)
+    if "/" in num_str:
+        folder, num_str = num_str.rsplit("/", 1)
+        await selectfolder(account, folder)
+        try:
+            res = await account.uid("FETCH", num_str, parts)
+        except (AioImapException, OSError) as err:
+            _LOGGER.error("Error fetching email text %s: %s", num_str, err)
+            return ("BAD", str(err))
+        else:
+            return (res.result, res.lines)
 
     try:
         res = await account.fetch(num_str, parts)
@@ -236,7 +410,7 @@ async def email_fetch_text(account: IMAP4_SSL, num, parts: str = "(BODY[1])") ->
         return (res.result, res.lines)
 
 
-async def email_fetch_batch(
+async def email_fetch_batch(  # noqa: C901
     account: IMAP4_SSL, nums: list[str | bytes], parts: str = "(RFC822)"
 ) -> tuple:
     """Download specified emails for parsing asynchronously in a batch."""
@@ -246,16 +420,55 @@ async def email_fetch_batch(
     if account.host == "imap.mail.me.com":
         parts = "BODY[]"
 
-    num_strs = [num.decode() if isinstance(num, bytes) else str(num) for num in nums]
-    num_list_str = ",".join(num_strs)
+    # Check if any ID contains a folder prefix
+    has_folder_prefix = False
+    for num in nums:
+        num_str = num.decode() if isinstance(num, bytes) else str(num)
+        if "/" in num_str:
+            has_folder_prefix = True
+            break
 
-    try:
-        res = await account.fetch(num_list_str, parts)
-    except (AioImapException, OSError) as err:
-        _LOGGER.error("Error fetching emails batch %s: %s", num_list_str, err)
-        return ("BAD", str(err))
-    else:
-        return (res.result, res.lines)
+    if not has_folder_prefix:
+        num_strs = [
+            num.decode() if isinstance(num, bytes) else str(num) for num in nums
+        ]
+        num_list_str = ",".join(num_strs)
+        try:
+            res = await account.fetch(num_list_str, parts)
+        except (AioImapException, OSError) as err:
+            _LOGGER.error("Error fetching emails batch %s: %s", num_list_str, err)
+            return ("BAD", str(err))
+        else:
+            return (res.result, res.lines)
+
+    # Group nums by their folder prefix
+    folder_to_nums = {}
+    for num in nums:
+        num_str = num.decode() if isinstance(num, bytes) else str(num)
+        if "/" in num_str:
+            folder, actual_num = num_str.rsplit("/", 1)
+        else:
+            folder, actual_num = None, num_str
+        folder_to_nums.setdefault(folder, []).append(actual_num)
+
+    all_results = []
+    overall_result = "OK"
+
+    for folder, folder_nums in folder_to_nums.items():
+        if folder is not None:
+            await selectfolder(account, folder)
+
+        num_list_str = ",".join(folder_nums)
+        try:
+            res = await account.uid("FETCH", num_list_str, parts)
+            if res.result != "OK":
+                overall_result = res.result
+            all_results.extend(res.lines)
+        except (AioImapException, OSError) as err:
+            _LOGGER.error("Error fetching emails batch %s: %s", num_list_str, err)
+            return ("BAD", str(err))
+
+    return (overall_result, all_results)
 
 
 async def logout(account: IMAP4_SSL | IMAP4) -> None:

--- a/custom_components/mail_and_packages/utils/imap.py
+++ b/custom_components/mail_and_packages/utils/imap.py
@@ -165,19 +165,32 @@ def build_search(
     return (False, imap_search)
 
 
-_ESEARCH_RE = re.compile(
-    r'\(TAG\s+"[^"]+"\s+MAILBOX\s+"([^"]+)"\s+UIDVALIDITY\s+\d+\)\s+UID\s+ALL\s+(.+)'
-)
-
-
 def _parse_esearch_line(line_bytes: bytes) -> list[bytes]:
     """Parse a single ESEARCH line and return list of formatted UID bytes: b'folder/uid'."""
     line_str = line_bytes.decode("utf-8", "ignore")
-    match = _ESEARCH_RE.search(line_str)
-    if not match:
+
+    # Extract the correlator inside parentheses
+    start_paren = line_str.find("(")
+    end_paren = line_str.find(")", start_paren) if start_paren != -1 else -1
+    if start_paren == -1 or end_paren == -1:
         return []
-    mailbox = match.group(1)
-    seq_set = match.group(2)
+
+    correlator = line_str[start_paren + 1 : end_paren]
+
+    # Extract mailbox name (could be quoted or unquoted)
+    mailbox_match = re.search(r'MAILBOX\s+"([^"]+)"', correlator)
+    if not mailbox_match:
+        mailbox_match = re.search(r"MAILBOX\s+(\S+)", correlator)
+    if not mailbox_match:
+        return []
+    mailbox = mailbox_match.group(1)
+
+    # Extract the sequence set after 'UID ALL' anywhere in the line
+    seq_match = re.search(r"UID\s+ALL\s+(\S+)", line_str)
+    if not seq_match:
+        return []
+    seq_set = seq_match.group(1)
+
     uids = []
     for part in seq_set.split(","):
         part = part.strip()
@@ -244,7 +257,14 @@ async def _execute_single_search(account: IMAP4_SSL, search_query: str) -> list[
             _LOGGER.error("Error executing ESEARCH: %s", err)
     else:
         # Sequential select and search fallback
-        for folder in folders:
+        # Limit sequential search to first 10 folders to prevent performance degradation
+        if len(folders) > 10:
+            _LOGGER.warning(
+                "Configured folders count (%d) exceeds the sequential search limit. "
+                "Only the first 10 folders will be searched to prevent excessive IMAP traffic.",
+                len(folders),
+            )
+        for folder in folders[:10]:
             select_ok = await selectfolder(account, folder)
             if not select_ok:
                 continue

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -14,6 +14,7 @@ from custom_components.mail_and_packages.utils.email import (
 )
 from custom_components.mail_and_packages.utils.imap import (
     InvalidAuth,
+    _parse_esearch_line,
     build_search,
     email_fetch,
     email_fetch_batch,
@@ -999,3 +1000,72 @@ async def test_email_fetch_batch_folder_prefix():
         mock_account.select.call_count == 1
     )  # selectfolder called only for Junk because _current_folder was already INBOX
     mock_account.select.assert_called_once_with("Junk")
+
+
+@pytest.mark.asyncio
+async def test_esearch_parser_variants():
+    """Test _parse_esearch_line with variations in spacing, order, and quoted/unquoted folder names."""
+    # Test mailbox unquoted
+    line_unquoted = (
+        b'* ESEARCH (TAG "1" MAILBOX INBOX UIDVALIDITY 123) UID ALL 1001:1002'
+    )
+    res = _parse_esearch_line(line_unquoted)
+    assert res == [b"INBOX/1001", b"INBOX/1002"]
+
+    # Test mailbox order changed (UIDVALIDITY before MAILBOX)
+    line_ordered = b'* ESEARCH (TAG "1" UIDVALIDITY 123 MAILBOX "Junk") UID ALL 2001'
+    res = _parse_esearch_line(line_ordered)
+    assert res == [b"Junk/2001"]
+
+    # Test variation in spacing
+    line_spacing = b'* ESEARCH  ( TAG  "1"  MAILBOX  "Inbox"  UIDVALIDITY  123 )  UID  ALL  3001,3003'
+    res = _parse_esearch_line(line_spacing)
+    assert res == [b"Inbox/3001", b"Inbox/3003"]
+
+
+@pytest.mark.asyncio
+async def test_esearch_parser_malformed():
+    """Test _parse_esearch_line with malformed/missing fields fails gracefully returning empty list."""
+    # Missing parenthesis
+    assert _parse_esearch_line(b'* ESEARCH TAG "1" MAILBOX "INBOX" UID ALL 1001') == []
+
+    # Missing MAILBOX
+    assert (
+        _parse_esearch_line(b'* ESEARCH (TAG "1" UIDVALIDITY 123) UID ALL 1001') == []
+    )
+
+    # Missing UID ALL
+    assert (
+        _parse_esearch_line(b'* ESEARCH (TAG "1" MAILBOX "INBOX" UIDVALIDITY 123) 1001')
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_email_search_sequential_fallback_capping(caplog):
+    """Test sequential fallback limit (capping at 10 folders) and warning logging."""
+    caplog.set_level("WARNING")
+    mock_account = AsyncMock()
+    # 12 folders configured
+    mock_account._folders = [f"Folder{i}" for i in range(12)]
+    mock_account.has_capability.return_value = False
+
+    # Mock uid_search response for each folder
+    mock_res = MagicMock(result="OK", lines=[b"1001"])
+    mock_account.uid_search.return_value = mock_res
+
+    # Mock list/select calls in selectfolder
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+
+    result = await email_search(
+        mock_account, ["test@example.com"], "25-Mar-2026", subject="Test"
+    )
+
+    assert result[0] == "OK"
+    # Select should only be called for the first 10 folders (Folder0 to Folder9)
+    assert mock_account.select.call_count == 10
+    assert (
+        "Configured folders count (12) exceeds the sequential search limit"
+        in caplog.text
+    )

--- a/tests/utils/test_imap_email.py
+++ b/tests/utils/test_imap_email.py
@@ -823,3 +823,179 @@ def test_build_search_multi_addr_multi_subject_parentheses():
     # Search must be wrapped in parens and include SINCE
     assert search.startswith("(")
     assert "SINCE 23-Apr-2026)" in search
+
+
+@pytest.mark.asyncio
+async def test_selectfolder_caching():
+    """Test that selectfolder caches the selected folder and avoids redundant list/select calls."""
+    mock_account = AsyncMock()
+    mock_account._current_folder = "INBOX"
+
+    # Select same folder - should return True immediately without calling list/select
+    res = await selectfolder(mock_account, "INBOX")
+    assert res is True
+    mock_account.list.assert_not_called()
+    mock_account.select.assert_not_called()
+
+    # Select different folder - should call list and select
+    mock_account._current_folder = "INBOX"
+    res = await selectfolder(mock_account, "Junk")
+    assert res is True
+    mock_account.list.assert_called_once_with("Junk", "*")
+    mock_account.select.assert_called_once_with("Junk")
+    assert mock_account._current_folder == "Junk"
+
+
+@pytest.mark.asyncio
+async def test_email_search_multisearch():
+    """Test email_search using ESEARCH (MULTISEARCH) capability."""
+    mock_account = AsyncMock()
+    mock_account._folders = ["INBOX", "Junk"]
+    mock_account.has_capability = MagicMock(return_value=True)
+
+    # Mock execute return value for Command ESEARCH
+    mock_res = MagicMock()
+    mock_res.result = "OK"
+    # ESEARCH response line with folder and range
+    mock_res.lines = [
+        b'* ESEARCH (TAG "1" MAILBOX "INBOX" UIDVALIDITY 123) UID ALL 1001:1003',
+        b'* ESEARCH (TAG "1" MAILBOX "Junk" UIDVALIDITY 123) UID ALL 2001',
+    ]
+
+    mock_protocol = AsyncMock()
+    mock_protocol.execute.return_value = mock_res
+    mock_protocol.new_tag.return_value = "1"
+    mock_protocol.loop = asyncio.get_running_loop()
+    mock_account.protocol = mock_protocol
+
+    result = await email_search(
+        mock_account, ["test@example.com"], "25-Mar-2026", subject="Test"
+    )
+
+    assert result[0] == "OK"
+    # UIDs should be parsed, expanded, and formatted as folder/uid
+    expected_uids = [
+        b"INBOX/1001",
+        b"INBOX/1002",
+        b"INBOX/1003",
+        b"Junk/2001",
+    ]
+    assert result[1] == [b" ".join(expected_uids)]
+
+
+@pytest.mark.asyncio
+async def test_email_search_sequential_fallback():
+    """Test email_search falling back to sequential searching when MULTISEARCH is absent."""
+    mock_account = AsyncMock()
+    mock_account._folders = ["INBOX", "Junk"]
+    mock_account.has_capability.return_value = False
+
+    # Mock uid_search response for each folder
+    mock_res1 = MagicMock(result="OK", lines=[b"1001 1002"])
+    mock_res2 = MagicMock(result="OK", lines=[b"2001"])
+    mock_account.uid_search.side_effect = [mock_res1, mock_res2]
+
+    # Mock list/select calls in selectfolder
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+
+    result = await email_search(
+        mock_account, ["test@example.com"], "25-Mar-2026", subject="Test"
+    )
+
+    assert result[0] == "OK"
+    expected_uids = [
+        b"INBOX/1001",
+        b"INBOX/1002",
+        b"Junk/2001",
+    ]
+    assert result[1] == [b" ".join(expected_uids)]
+
+
+@pytest.mark.asyncio
+async def test_email_fetch_folder_prefix():
+    """Test email_fetch with folder-prefixed UID."""
+    mock_account = AsyncMock()
+    mock_account._current_folder = "INBOX"
+
+    # Mock list/select/uid
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+    mock_res = MagicMock(result="OK", lines=[b"RFC822", b"body"])
+    mock_account.uid.return_value = mock_res
+
+    result = await email_fetch(mock_account, b"Junk/2001")
+    assert result[0] == "OK"
+    assert result[1] == [b"RFC822", b"body"]
+
+    # Verify selectfolder was called for Junk and uid fetch executed
+    mock_account.select.assert_called_once_with("Junk")
+    mock_account.uid.assert_called_once_with("FETCH", "2001", "(RFC822)")
+
+
+@pytest.mark.asyncio
+async def test_email_fetch_headers_folder_prefix():
+    """Test email_fetch_headers with folder-prefixed UID."""
+    mock_account = AsyncMock()
+    mock_account._current_folder = "INBOX"
+
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+    mock_res = MagicMock(result="OK", lines=[b"Subject: Hello"])
+    mock_account.uid.return_value = mock_res
+
+    result = await email_fetch_headers(mock_account, b"Junk/2001")
+    assert result[0] == "OK"
+    assert result[1] == [b"Subject: Hello"]
+
+    mock_account.select.assert_called_once_with("Junk")
+    mock_account.uid.assert_called_once_with(
+        "FETCH", "2001", "(BODY[HEADER.FIELDS (SUBJECT)])"
+    )
+
+
+@pytest.mark.asyncio
+async def test_email_fetch_text_folder_prefix():
+    """Test email_fetch_text with folder-prefixed UID."""
+    mock_account = AsyncMock()
+    mock_account._current_folder = "INBOX"
+
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+    mock_res = MagicMock(result="OK", lines=[b"text body"])
+    mock_account.uid.return_value = mock_res
+
+    result = await email_fetch_text(mock_account, b"Junk/2001")
+    assert result[0] == "OK"
+    assert result[1] == [b"text body"]
+
+    mock_account.select.assert_called_once_with("Junk")
+    mock_account.uid.assert_called_once_with("FETCH", "2001", "(BODY[1])")
+
+
+@pytest.mark.asyncio
+async def test_email_fetch_batch_folder_prefix():
+    """Test email_fetch_batch with folder-prefixed UIDs."""
+    mock_account = AsyncMock()
+    mock_account._current_folder = "INBOX"
+
+    mock_account.list.return_value = MagicMock()
+    mock_account.select.return_value = MagicMock()
+
+    # Mock fetch results for different folders
+    mock_res1 = MagicMock(result="OK", lines=[b"body1"])
+    mock_res2 = MagicMock(result="OK", lines=[b"body2"])
+    mock_account.uid.side_effect = [mock_res1, mock_res2]
+
+    uids = [b"INBOX/1001", b"Junk/2001"]
+    result = await email_fetch_batch(mock_account, uids)
+
+    assert result[0] == "OK"
+    assert result[1] == [b"body1", b"body2"]
+
+    # Verify folder switches and UID fetches
+    # 1001 should fetch in INBOX, 2001 in Junk
+    assert (
+        mock_account.select.call_count == 1
+    )  # selectfolder called only for Junk because _current_folder was already INBOX
+    mock_account.select.assert_called_once_with("Junk")


### PR DESCRIPTION
## Proposed change

Adds multi-folder IMAP email search with a hybrid strategy:

1. **ESEARCH/MULTISEARCH (RFC 7377)** — when the server advertises the `MULTISEARCH` capability, a single `ESEARCH` command is issued across all configured folders in one round-trip, maximising efficiency.
2. **Sequential fallback** — for servers without `MULTISEARCH`, folders are searched one-by-one (capped at 10, with a logged warning when more are configured to prevent unbounded latency).

Additional improvements shipped in this PR:
- **Folder-selection caching** in `selectfolder()` to skip redundant `SELECT` commands when the same folder is already active.
- **Folder-prefixed UID routing** (`INBOX/123`) throughout all `email_fetch*` helpers so results from multiple folders are unambiguous.
- **`CONF_FOLDER` multi-select UI** — the config flow now uses `cv.multi_select` so users can pick multiple folders from a drop-down; single-item selections are normalised back to a plain string for backwards compatibility.
- **Robust `_parse_esearch_line` parser** — handles flexible spacing, varying attribute order, and quoted/unquoted mailbox names per RFC 7377.
- **Defensive coordinator defaults** — empty or non-list folder configs default to `["INBOX"]`.

## Type of change

- [x] New feature (which adds functionality)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #1256
- This PR is related to issue: #1256

### Testing

- All 485 existing tests continue to pass (`uv run pytest --no-cov`).
- New unit tests added in `tests/utils/test_imap_email.py`:
  - `test_esearch_parser_variants` — covers unquoted mailbox, reordered attributes, and varied spacing.
  - `test_esearch_parser_malformed` — verifies graceful empty-list return on missing parenthesis, missing `MAILBOX`, and missing `UID ALL`.
  - `test_email_search_sequential_fallback_capping` — verifies only 10 folders are searched and the warning is logged when 12 are configured.