### PR TITLE
fix(hermes): add support for Hermes DE delivered and delivering notifications

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -521,8 +521,15 @@ SENSOR_DATA = {
     },
     # Hermes.co.uk
     "hermes_delivered": {
-        "email": ["donotreply@myhermes.co.uk"],
-        "subject": ["Hermes has successfully delivered your"],
+        "email": [
+            "donotreply@myhermes.co.uk",
+            "noreply@paketankuendigung.myhermes.de",
+        ],
+        "subject": [
+            "Hermes has successfully delivered your",
+            "wurde an deinen WunschAblageort zugestellt",
+            "wurde zugestellt",
+        ],
     },
     "hermes_delivering": {
         "email": [
@@ -533,9 +540,11 @@ SENSOR_DATA = {
             "parcel is now with your local Hermes courier",
             "Ihre Hermes Sendung",
             "Deine Hermes Sendung",
+            "Deine Sendung kommt heute",
         ],
         "body": [
             "Voraussichtliche Zustellung",
+            "ist unterwegs",
         ],
     },
     "hermes_packages": {},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -930,6 +930,30 @@ def mock_imap_hermes_out_for_delivery(mock_imap):
 
 
 @pytest.fixture
+def mock_imap_hermes_de_delivered(mock_imap):
+    """Mock IMAP search with Hermes Germany delivered email."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.uid.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_file = Path("tests/test_emails/hermes_de_delivered.eml").read_text(
+        encoding="utf-8",
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
+    return mock_imap
+
+
+@pytest.fixture
+def mock_imap_hermes_de_delivering_today(mock_imap):
+    """Mock IMAP search with Hermes Germany delivering today email."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.uid.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_file = Path("tests/test_emails/hermes_de_delivering_today.eml").read_text(
+        encoding="utf-8",
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_file)
+    return mock_imap
+
+
+@pytest.fixture
 def mock_imap_evri_out_for_delivery(mock_imap):
     """Mock IMAP search with Evri out for delivery email."""
     mock_imap.select.return_value = ("OK", [b""])

--- a/tests/shippers/test_hermes.py
+++ b/tests/shippers/test_hermes.py
@@ -1,0 +1,32 @@
+"""Tests for the Hermes DE shipper."""
+
+import pytest
+
+from custom_components.mail_and_packages.const import ATTR_COUNT, ATTR_TRACKING
+from custom_components.mail_and_packages.shippers.generic import GenericShipper
+
+
+@pytest.mark.asyncio
+async def test_hermes_de_delivered(hass, mock_imap_hermes_de_delivered):
+    """Test Hermes DE delivered email parsing."""
+    shipper = GenericShipper(hass, {})
+    result = await shipper.process(
+        mock_imap_hermes_de_delivered,
+        "today",
+        "hermes_delivered",
+    )
+    assert result[ATTR_COUNT] == 1
+    assert result[ATTR_TRACKING] == ["12345678901234"]
+
+
+@pytest.mark.asyncio
+async def test_hermes_de_delivering_today(hass, mock_imap_hermes_de_delivering_today):
+    """Test Hermes DE delivering today email parsing."""
+    shipper = GenericShipper(hass, {})
+    result = await shipper.process(
+        mock_imap_hermes_de_delivering_today,
+        "today",
+        "hermes_delivering",
+    )
+    assert result[ATTR_COUNT] == 1
+    assert result[ATTR_TRACKING] == ["98765432109876"]

--- a/tests/test_emails/hermes_de_delivered.eml
+++ b/tests/test_emails/hermes_de_delivered.eml
@@ -1,0 +1,9 @@
+From: noreply@paketankuendigung.myhermes.de
+To: my_email_address@gmail.com
+Subject: Dein Hermes Paket von shop wurde an deinen WunschAblageort zugestellt.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hallo,
+deine Sendung von shop wurde an deinem WunschAblageort zugestellt.
+Hier ist die Sendungsnummer: 12345678901234

--- a/tests/test_emails/hermes_de_delivering_today.eml
+++ b/tests/test_emails/hermes_de_delivering_today.eml
@@ -1,0 +1,9 @@
+From: noreply@paketankuendigung.myhermes.de
+To: my_email_address@gmail.com
+Subject: Deine Sendung kommt heute.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+Hallo,
+deine Sendung von shop ist unterwegs und wird dir heute zugestellt.
+Hier ist die Sendungsnummer: 98765432109876


### PR DESCRIPTION
This PR resolves #1285 by adding support for Hermes Germany (`myhermes.de`) delivery and out-for-delivery notifications:

1. **German Delivered Notifications:**
   - Added `noreply@paketankuendigung.myhermes.de` sender and German subject patterns (`"wurde an deinen WunschAblageort zugestellt"`, `"wurde zugestellt"`) to `hermes_delivered`.

2. **German Delivering Notifications:**
   - Added `"Deine Sendung kommt heute"` subject pattern and `"ist unterwegs"` body pattern to `hermes_delivering`.

3. **Unit Tests:**
   - Added mock emails (`hermes_de_delivered.eml`, `hermes_de_delivering_today.eml`) and matching unit tests in `tests/shippers/test_hermes.py` to cover both scenarios.