### PR TITLE
feat(shippers): add support for Swedish carriers and amazon.se (#838)

### DIFF
--- a/custom_components/mail_and_packages/const.py
+++ b/custom_components/mail_and_packages/const.py
@@ -147,6 +147,7 @@ AMAZON_DOMAINS = [
     "amazon.fr",
     "amazon.ae",
     "amazon.nl",
+    "amazon.se",
 ]
 AMAZON_DELIVERED_SUBJECT = [
     "Delivered: ",
@@ -1088,6 +1089,89 @@ SENSOR_DATA = {
     },
     "bolcom_packages": {},
     "bolcom_tracking": {"pattern": ["3S[A-Z0-9]{10,18}", "JJD\\d{14,25}", "\\d{14}"]},
+    # PostNord (Sweden)
+    "postnord_delivered": {
+        "email": [
+            "no-reply@postnord.com",
+            "avisering@postnord.se",
+        ],
+        "subject": [
+            "finns att hämta",
+            "finns att hamta",
+            "har levererats",
+            "Levererad",
+        ],
+    },
+    "postnord_delivering": {
+        "email": [
+            "no-reply@postnord.com",
+            "avisering@postnord.se",
+        ],
+        "subject": [
+            "Leverans på väg",
+            "Leverans pa vag",
+            "är på väg",
+            "ar pa vag",
+            "på väg till dig",
+            "pa vag till dig",
+        ],
+    },
+    "postnord_packages": {},
+    "postnord_tracking": {"pattern": ["[0-9]{13,18}SE", "SE[0-9]{9}SE"]},
+    # Bring (Sweden/Norway)
+    "bring_delivered": {
+        "email": [
+            "no-reply@bring.com",
+            "notification@bring.com",
+        ],
+        "subject": [
+            "paket att hämta",
+            "paket att hamta",
+            "har levererats",
+        ],
+    },
+    "bring_delivering": {
+        "email": [
+            "no-reply@bring.com",
+            "notification@bring.com",
+        ],
+        "subject": [
+            "sändning är på väg",
+            "sandning ar pa vag",
+            "sändning har skickats",
+            "sandning har skickats",
+            "Paket på väg",
+            "Paket pa vag",
+        ],
+    },
+    "bring_packages": {},
+    "bring_tracking": {"pattern": ["PARCEL[0-9A-Z]{10,20}", "CT[0-9]{9}NO"]},
+    # DB Schenker (Sweden)
+    "db_schenker_delivered": {
+        "email": [
+            "no-reply@dbschenker.com",
+            "no-reply@dsv.com",
+        ],
+        "subject": [
+            "finns nu att hämta",
+            "finns nu att hamta",
+            "har levererats",
+        ],
+    },
+    "db_schenker_delivering": {
+        "email": [
+            "no-reply@dbschenker.com",
+            "no-reply@dsv.com",
+        ],
+        "subject": [
+            "Avisering om paket",
+            "Leveransbesked",
+            "är på väg",
+            "ar pa vag",
+        ],
+    },
+    "db_schenker_packages": {},
+    "db_schenker_tracking": {"pattern": ["\\d{10,16}"]},
 }
 
 # Sensor definitions
@@ -1774,6 +1858,63 @@ CAMERA_EXTRACTION_CONFIG = {
         "image_type": "jpeg",
         "attachment_filename_pattern": "delivery",
     },
+    # PostNord
+    "postnord_delivered": SensorEntityDescription(
+        name="Mail PostNord Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="postnord_delivered",
+    ),
+    "postnord_delivering": SensorEntityDescription(
+        name="Mail PostNord Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="postnord_delivering",
+    ),
+    "postnord_packages": SensorEntityDescription(
+        name="Mail PostNord Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="postnord_packages",
+    ),
+    # Bring
+    "bring_delivered": SensorEntityDescription(
+        name="Mail Bring Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="bring_delivered",
+    ),
+    "bring_delivering": SensorEntityDescription(
+        name="Mail Bring Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="bring_delivering",
+    ),
+    "bring_packages": SensorEntityDescription(
+        name="Mail Bring Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="bring_packages",
+    ),
+    # DB Schenker
+    "db_schenker_delivered": SensorEntityDescription(
+        name="Mail DB Schenker Delivered",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="db_schenker_delivered",
+    ),
+    "db_schenker_delivering": SensorEntityDescription(
+        name="Mail DB Schenker Delivering",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:truck-delivery",
+        key="db_schenker_delivering",
+    ),
+    "db_schenker_packages": SensorEntityDescription(
+        name="Mail DB Schenker Packages",
+        native_unit_of_measurement="package(s)",
+        icon="mdi:package-variant-closed",
+        key="db_schenker_packages",
+    ),
 }
 
 # Sensor Index
@@ -1809,6 +1950,9 @@ SHIPPERS = [
     "poczta_polska",
     "buildinglink",
     "post_de",
+    "postnord",
+    "bring",
+    "db_schenker",
 ]
 
 # Authentication types

--- a/tests/shippers/test_swedish_shippers.py
+++ b/tests/shippers/test_swedish_shippers.py
@@ -1,0 +1,96 @@
+"""Tests for Swedish carrier shippers (PostNord, Bring, DB Schenker)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.mail_and_packages.const import ATTR_COUNT, ATTR_TRACKING
+from custom_components.mail_and_packages.shippers.generic import GenericShipper
+from tests.conftest import _generate_fetch_side_effect
+
+
+@pytest.fixture
+def mock_imap_postnord_delivered(mock_imap):
+    """Mock IMAP connection returning PostNord delivered email."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.search.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_text = (
+        "From: avisering@postnord.se\n"
+        "Subject: Ditt paket fran Store finns att hamta\n"
+        "Date: Fri, 24 Jul 2026 12:00:00 +0200\n"
+        "\n"
+        "Ditt paket 1234567890123SE finns att hamta hos ditt ombud."
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_text)
+    return mock_imap
+
+
+@pytest.fixture
+def mock_imap_bring_delivering(mock_imap):
+    """Mock IMAP connection returning Bring delivering email."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.search.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_text = (
+        "From: no-reply@bring.com\n"
+        "Subject: Din sandning ar pa vag\n"
+        "Date: Fri, 24 Jul 2026 12:00:00 +0200\n"
+        "\n"
+        "Din sandning PARCEL1234567890NO ar pa vag till dig."
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_text)
+    return mock_imap
+
+
+@pytest.fixture
+def mock_imap_db_schenker_delivered(mock_imap):
+    """Mock IMAP connection returning DB Schenker delivered email."""
+    mock_imap.select.return_value = ("OK", [b""])
+    mock_imap.search.return_value = MagicMock(result="OK", lines=[b"1"])
+    email_text = (
+        "From: no-reply@dbschenker.com\n"
+        "Subject: Ditt paket finns nu att hamta\n"
+        "Date: Fri, 24 Jul 2026 12:00:00 +0200\n"
+        "\n"
+        "Ditt paket 9876543210 finns nu att hamta."
+    )
+    mock_imap.fetch.side_effect = _generate_fetch_side_effect(email_text)
+    return mock_imap
+
+
+@pytest.mark.asyncio
+async def test_postnord_delivered(hass, mock_imap_postnord_delivered):
+    """Test PostNord delivered email parsing."""
+    shipper = GenericShipper(hass, {})
+    result = await shipper.process(
+        mock_imap_postnord_delivered,
+        "today",
+        "postnord_delivered",
+    )
+    assert result[ATTR_COUNT] == 1
+    assert result[ATTR_TRACKING] == ["1234567890123SE"]
+
+
+@pytest.mark.asyncio
+async def test_bring_delivering(hass, mock_imap_bring_delivering):
+    """Test Bring delivering email parsing."""
+    shipper = GenericShipper(hass, {})
+    result = await shipper.process(
+        mock_imap_bring_delivering,
+        "today",
+        "bring_delivering",
+    )
+    assert result[ATTR_COUNT] == 1
+    assert result[ATTR_TRACKING] == ["PARCEL1234567890NO"]
+
+
+@pytest.mark.asyncio
+async def test_db_schenker_delivered(hass, mock_imap_db_schenker_delivered):
+    """Test DB Schenker delivered email parsing."""
+    shipper = GenericShipper(hass, {})
+    result = await shipper.process(
+        mock_imap_db_schenker_delivered,
+        "today",
+        "db_schenker_delivered",
+    )
+    assert result[ATTR_COUNT] == 1
+    assert result[ATTR_TRACKING] == ["9876543210"]


### PR DESCRIPTION
## Description
Addresses #838 by adding carrier definitions for Swedish shipping providers (**PostNord**, **Bring**, and **DB Schenker**) and registering `"amazon.se"` in `AMAZON_DOMAINS`.

### Changes Included
- **Amazon Sweden**: Added `"amazon.se"` to `AMAZON_DOMAINS` in `custom_components/mail_and_packages/const.py`.
- **Swedish Carriers**: Registered `postnord`, `bring`, and `db_schenker` in `SENSOR_DATA`, `SENSOR_TYPES`, and `SHIPPERS` in `const.py`.
- **Tests**: Added unit tests in `tests/shippers/test_swedish_shippers.py` verifying carrier email parsing.

Closes #838