### PR TITLE
fix(sensor): retain last known state for image path sensors

### DIFF
--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -4,17 +4,18 @@ https://blog.kalavala.net/usps/homeassistant/mqtt/2018/01/12/usps.html
 Configuration code contribution from @firstof9 https://github.com/firstof9/
 """
 
-import contextlib
 import datetime
 import logging
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import (
+    RestoreSensor,
+    SensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_RESOURCES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import NoURLAvailableError, get_url
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MailAndPackagesConfigEntry
@@ -69,7 +70,7 @@ async def async_setup_entry(
     async_add_entities(sensors, False)
 
 
-class PackagesSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
+class PackagesSensor(CoordinatorEntity, RestoreSensor):
     """Representation of a sensor."""
 
     def __init__(
@@ -101,17 +102,8 @@ class PackagesSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added to hass."""
         await super().async_added_to_hass()
-        if (state := await self.async_get_last_state()) is not None:
-            if self.type == "mail_updated":
-                with contextlib.suppress(ValueError):
-                    self._attr_native_value = datetime.datetime.fromisoformat(
-                        state.state
-                    )
-            elif self.entity_description.native_unit_of_measurement:
-                with contextlib.suppress(ValueError):
-                    self._attr_native_value = int(state.state)
-            else:
-                self._attr_native_value = state.state
+        if (sensor_data := await self.async_get_last_sensor_data()) is not None:
+            self._attr_native_value = sensor_data.native_value
 
     @property
     def device_info(self) -> dict:
@@ -197,7 +189,7 @@ class PackagesSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
                 attr[ATTR_CODE] = code
 
 
-class ImagePathSensors(CoordinatorEntity, RestoreEntity, SensorEntity):
+class ImagePathSensors(CoordinatorEntity, RestoreSensor):
     """Representation of a sensor."""
 
     def __init__(
@@ -221,8 +213,8 @@ class ImagePathSensors(CoordinatorEntity, RestoreEntity, SensorEntity):
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added to hass."""
         await super().async_added_to_hass()
-        if (state := await self.async_get_last_state()) is not None:
-            self._attr_native_value = state.state
+        if (sensor_data := await self.async_get_last_sensor_data()) is not None:
+            self._attr_native_value = sensor_data.native_value
 
     @property
     def device_info(self) -> dict:

--- a/custom_components/mail_and_packages/sensor.py
+++ b/custom_components/mail_and_packages/sensor.py
@@ -4,6 +4,7 @@ https://blog.kalavala.net/usps/homeassistant/mqtt/2018/01/12/usps.html
 Configuration code contribution from @firstof9 https://github.com/firstof9/
 """
 
+import contextlib
 import datetime
 import logging
 from typing import Any
@@ -13,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_RESOURCES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import NoURLAvailableError, get_url
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MailAndPackagesConfigEntry
@@ -67,7 +69,7 @@ async def async_setup_entry(
     async_add_entities(sensors, False)
 
 
-class PackagesSensor(CoordinatorEntity, SensorEntity):
+class PackagesSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
     """Representation of a sensor."""
 
     def __init__(
@@ -96,6 +98,21 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
         else:
             self._tracking_key = f"{self.type}_tracking"
 
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added to hass."""
+        await super().async_added_to_hass()
+        if (state := await self.async_get_last_state()) is not None:
+            if self.type == "mail_updated":
+                with contextlib.suppress(ValueError):
+                    self._attr_native_value = datetime.datetime.fromisoformat(
+                        state.state
+                    )
+            elif self.entity_description.native_unit_of_measurement:
+                with contextlib.suppress(ValueError):
+                    self._attr_native_value = int(state.state)
+            else:
+                self._attr_native_value = state.state
+
     @property
     def device_info(self) -> dict:
         """Return device information about the mailbox."""
@@ -120,7 +137,7 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
     def native_value(self) -> Any:
         """Return the state of the sensor."""
         if self.coordinator.data is None:
-            return None
+            return getattr(self, "_attr_native_value", None)
         value = self.coordinator.data.get(self.type)
 
         if self.type == "mail_updated":
@@ -130,9 +147,12 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
                     value = datetime.datetime.fromisoformat(value)
                 except ValueError:
                     value = datetime.datetime.now(datetime.UTC)
-            elif value is None:
+            elif value is None and getattr(self, "_attr_native_value", None) is None:
                 value = datetime.datetime.now(datetime.UTC)
-        return value
+
+        if value is not None:
+            self._attr_native_value = value
+        return getattr(self, "_attr_native_value", None)
 
     @property
     def should_poll(self) -> bool:
@@ -177,7 +197,7 @@ class PackagesSensor(CoordinatorEntity, SensorEntity):
                 attr[ATTR_CODE] = code
 
 
-class ImagePathSensors(CoordinatorEntity, SensorEntity):
+class ImagePathSensors(CoordinatorEntity, RestoreEntity, SensorEntity):
     """Representation of a sensor."""
 
     def __init__(
@@ -197,6 +217,12 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
         self.type = sensor_description.key
         self._host = config.data[CONF_HOST]
         self._unique_id = self._config.entry_id
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added to hass."""
+        await super().async_added_to_hass()
+        if (state := await self.async_get_last_state()) is not None:
+            self._attr_native_value = state.state
 
     @property
     def device_info(self) -> dict:
@@ -222,10 +248,7 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
     def native_value(self) -> str | None:
         """Return the state of the sensor."""
         if self.coordinator.data is None:
-            return None
-
-        image = ""
-        the_path = None
+            return getattr(self, "_attr_native_value", None)
 
         image = self.coordinator.data.get(ATTR_USPS_IMAGE)
 
@@ -235,6 +258,8 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
             ATTR_IMAGE_PATH,
             self.coordinator.config.get(CONF_PATH),
         )
+
+        the_path = None
 
         if self.type == "usps_mail_image_system_path" and image:
             _LOGGER.debug("Updating system image path to: %s", path)
@@ -246,7 +271,11 @@ class ImagePathSensors(CoordinatorEntity, SensorEntity):
             url = self._get_base_url()
             if url:
                 the_path = f"{url.rstrip('/')}/local/mail_and_packages/{image}"
-        return the_path
+
+        if the_path is not None:
+            self._attr_native_value = the_path
+
+        return getattr(self, "_attr_native_value", None)
 
     def _get_base_url(self) -> str | None:
         """Return the best available base URL for building image links."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -472,3 +472,29 @@ async def test_image_path_sensor_grid(hass):
     )
     expected = f"{hass.config.path()}/images/test_grid.png"
     assert sensor.native_value == expected
+
+
+@pytest.mark.asyncio
+async def test_image_path_sensor_state_retention(hass):
+    """Test that ImagePathSensors retains last known good state when image is missing."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: "test"})
+    coordinator = MagicMock()
+    coordinator.data = {
+        "usps_image": "test.gif",
+        "image_path": "images/",
+    }
+
+    sensor = ImagePathSensors(
+        hass,
+        entry,
+        MagicMock(
+            key="usps_mail_image_system_path", name="USPS Mail Image System Path"
+        ),
+        coordinator,
+    )
+    expected = f"{hass.config.path()}/images/test.gif"
+    assert sensor.native_value == expected
+
+    # Simulate next update having no new usps_image data
+    coordinator.data = {"image_path": "images/"}
+    assert sensor.native_value == expected


### PR DESCRIPTION
## Proposed change

Update `ImagePathSensors` and `PackagesSensor` to inherit from `RestoreEntity` and preserve their last known valid state (`_attr_native_value`).

When a scan or poll cycle does not return new image path data, instead of reverting `native_value` to `None` (which Home Assistant displays as `unknown`), the entities now retain their last known valid state. Additionally, `RestoreEntity` ensures state retention across Home Assistant restarts.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update
- [ ] Adds a new shipper
- [ ] Update existing shipper

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensors now retain their last known values after Home Assistant restarts.
  * Package and image path sensors continue displaying their previous values when coordinator data is temporarily unavailable or incomplete.
  * Image path sensor values are preserved when image information is removed from updates.

* **Tests**
  * Added coverage verifying image path values remain available after incomplete coordinator updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->